### PR TITLE
index-template: Template configuration.

### DIFF
--- a/invenio_record_editor/config.py
+++ b/invenio_record_editor/config.py
@@ -1,4 +1,5 @@
-{#
+# -*- coding: utf-8 -*-
+#
 # This file is part of Invenio.
 # Copyright (C) 2016 CERN.
 #
@@ -20,24 +21,7 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
-#}
-{%- extends config.RECORD_EDITOR_BASE_TEMPLATE -%}
 
-{%- block page_body %}
-<re-app>
-	Loading...
-</re-app>
+"""Invenio module for editing JSON records."""
 
-{% endblock page_body %}
-
-
-{%- block page_footer %}
-{%- endblock page_footer %}
- 
-{% block javascript %}
-
-{% assets "invenio_record_editor_js" %}
-  <script src="{{ ASSET_URL }}"></script>
-{% endassets %}
-
-{% endblock javascript %}
+RECORD_EDITOR_INDEX_TEMPLATE = 'invenio_record_editor/index.html'

--- a/invenio_record_editor/ext.py
+++ b/invenio_record_editor/ext.py
@@ -26,6 +26,7 @@
 
 from __future__ import absolute_import, print_function
 
+from . import config
 from .views import blueprint
 
 
@@ -46,6 +47,9 @@ class InvenioRecordEditor(object):
     def init_config(self, app):
         """Initialize configuration."""
         app.config.setdefault(
-            "RECORDEDITOR_BASE_TEMPLATE",
+            "RECORD_EDITOR_BASE_TEMPLATE",
             app.config.get("BASE_TEMPLATE",
                            "invenio_record_editor/base.html"))
+        for k in dir(config):
+            if k.startswith('RECORD_EDITOR_'):
+                app.config.setdefault(k, getattr(config, k))

--- a/invenio_record_editor/views.py
+++ b/invenio_record_editor/views.py
@@ -26,7 +26,7 @@
 
 from __future__ import absolute_import, print_function
 
-from flask import Blueprint, render_template
+from flask import Blueprint, current_app, render_template
 
 blueprint = Blueprint(
     'invenio_record_editor',
@@ -40,5 +40,4 @@ blueprint = Blueprint(
 @blueprint.route("/")
 def index():
     """Basic view."""
-    return render_template(
-        "invenio_record_editor/index.html")
+    return render_template(current_app.config['RECORD_EDITOR_INDEX_TEMPLATE'])


### PR DESCRIPTION
* Includes template configuration for `index.html`. Retrieves template from the variable
   `RECORD_EDITOR_INDEX_TEMPLATE` in `invenio_record_editor/config.py`.

Signed-off-by: Zacharias Zacharodimos <zacharias.zacharodimos@cern.ch>